### PR TITLE
fix: Improve homepage dropdown

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,9 +57,10 @@ class _MyHomePageState extends State<MyHomePage> {
 
   List<PopupMenuItem> get menuItems => [
         PopupMenuItem(
-          child: IconButton(
-            icon: const Icon(Icons.brightness_4),
-            onPressed: () {
+          child: ListTile(
+            leading: const Icon(Icons.brightness_4),
+            title: Text('Switch theme'),
+            onTap: () {
               if (AdaptiveTheme.of(context).mode == AdaptiveThemeMode.dark) {
                 AdaptiveTheme.of(context).setLight();
               } else {
@@ -69,9 +70,10 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
         ),
         PopupMenuItem(
-          child: IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () {
+          child: ListTile(
+            leading: const Icon(Icons.settings),
+            title: Text('Settings'),
+            onTap: () {
               Navigator.pop(context);
               Navigator.pushNamed(context, '/settings');
             },

--- a/lib/translations.dart
+++ b/lib/translations.dart
@@ -15,6 +15,7 @@ class Translations {
       'newUpdateAvailable': 'New Update Available',
       'latestRelease': 'Latest Release',
       'githubRepo': 'GitHub repo',
+      'switchTheme': 'Switch theme', // Pf7e1
     },
     'sv': {
       'settings': 'Inställningar',
@@ -29,6 +30,7 @@ class Translations {
       'newUpdateAvailable': 'Ny uppdatering tillgänglig',
       'latestRelease': 'Senaste versionen',
       'githubRepo': 'GitHub-repo',
+      'switchTheme': 'Byt tema', // Pf7e1
     },
   };
 


### PR DESCRIPTION
Fixes #63

Improve the homepage dropdown by adding text labels and making buttons clickable.

* Replace `IconButton` widgets with `ListTile` widgets for "Settings" and "Switch theme" buttons in `lib/main.dart`
* Add text labels "Settings" and "Switch theme" to the `ListTile` widgets in `lib/main.dart`
* Update the `PopupMenuItem` widget to use the `ListTile` widgets in `lib/main.dart`
* Add translation keys for "Switch theme" button in `lib/translations.dart`
* Add translations for "Switch theme" button in supported languages in `lib/translations.dart`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bl4ckswordsman/abc_app/pull/76?shareId=a8ef8fbd-228f-43a4-ae2e-18973f2dce69).